### PR TITLE
Adds unload_solution support via out-of-process worker.

### DIFF
--- a/src/Logger.cs
+++ b/src/Logger.cs
@@ -1,0 +1,51 @@
+namespace SharpLensMcp;
+
+/// <summary>
+/// Log severity levels in increasing order of importance.
+/// </summary>
+public enum LogLevel
+{
+    Trace = 0,
+    Debug = 1,
+    Information = 2,
+    Warning = 3,
+    Error = 4
+}
+
+/// <summary>
+/// Shared logging utility for consistent log formatting across all components.
+/// Logs to stderr with timestamp, source, and level.
+/// </summary>
+public static class Logger
+{
+    private static LogLevel? _cachedConfiguredLevel;
+
+    /// <summary>
+    /// Logs a message to stderr if the configured log level allows it.
+    /// </summary>
+    /// <param name="source">The source component (e.g., "Worker", "Proxy", "ProcessManager")</param>
+    /// <param name="level">Log level</param>
+    /// <param name="message">The message to log</param>
+    public static void Log(string source, LogLevel level, string message)
+    {
+        var configuredLevel = GetConfiguredLevel();
+
+        if (level >= configuredLevel)
+        {
+            Console.Error.WriteLine($"[{DateTime.Now:HH:mm:ss}] [{source}] [{level}] {message}");
+        }
+    }
+
+    private static LogLevel GetConfiguredLevel()
+    {
+        if (_cachedConfiguredLevel.HasValue)
+            return _cachedConfiguredLevel.Value;
+
+        var envValue = Environment.GetEnvironmentVariable("ROSLYN_LOG_LEVEL");
+        _cachedConfiguredLevel = Enum.TryParse<LogLevel>(envValue, ignoreCase: true, out var parsed)
+            ? parsed
+            : LogLevel.Information;
+
+        return _cachedConfiguredLevel.Value;
+    }
+}

--- a/src/ProcessManager.cs
+++ b/src/ProcessManager.cs
@@ -1,0 +1,306 @@
+using System.Diagnostics;
+
+namespace SharpLensMcp;
+
+/// <summary>
+/// Manages the worker process lifecycle: spawning, monitoring, and termination.
+/// The worker process runs the same executable with --worker flag.
+/// </summary>
+public class ProcessManager : IDisposable
+{
+    private Process? _workerProcess;
+    private RoslynWorkerProxy? _proxy;
+    private readonly object _lock = new();
+    private readonly SemaphoreSlim _spawnLock = new(1, 1);
+    private bool _disposed;
+
+    /// <summary>
+    /// The last solution path that was loaded, used for auto-reload after respawn.
+    /// </summary>
+    public string? LastLoadedSolutionPath { get; set; }
+
+    /// <summary>
+    /// Gets when the worker was last started.
+    /// </summary>
+    public DateTime? WorkerStartTime { get; private set; }
+
+    /// <summary>
+    /// Gets whether a worker process is currently running.
+    /// </summary>
+    public bool IsWorkerRunning
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _workerProcess != null && !_workerProcess.HasExited;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the worker process ID, or null if not running.
+    /// </summary>
+    public int? WorkerProcessId
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _workerProcess != null && !_workerProcess.HasExited ? _workerProcess.Id : null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets worker uptime, or null if not running.
+    /// </summary>
+    public TimeSpan? WorkerUptime
+    {
+        get
+        {
+            if (WorkerStartTime == null || !IsWorkerRunning)
+                return null;
+            return DateTime.UtcNow - WorkerStartTime.Value;
+        }
+    }
+
+    /// <summary>
+    /// Ensures a worker is running and returns the proxy. Spawns if needed.
+    /// </summary>
+    public async Task<RoslynWorkerProxy> EnsureWorkerAsync()
+    {
+        // Fast path: check if worker is already running
+        lock (_lock)
+        {
+            if (_proxy != null && IsWorkerRunning)
+            {
+                return _proxy;
+            }
+        }
+
+        // Slow path: acquire async lock to spawn worker (prevents race condition)
+        await _spawnLock.WaitAsync();
+        try
+        {
+            // Double-check after acquiring lock
+            lock (_lock)
+            {
+                if (_proxy != null && IsWorkerRunning)
+                {
+                    return _proxy;
+                }
+            }
+
+            // Need to spawn (or respawn) worker
+            return await SpawnWorkerAsync();
+        }
+        finally
+        {
+            _spawnLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Spawns a new worker process, killing any existing one first.
+    /// </summary>
+    public async Task<RoslynWorkerProxy> SpawnWorkerAsync()
+    {
+        lock (_lock)
+        {
+            if (_workerProcess != null)
+            {
+                CleanupWorker();
+            }
+        }
+
+        var executablePath = Environment.ProcessPath
+            ?? throw new InvalidOperationException("Could not determine executable path for worker process");
+
+        Log(LogLevel.Information, $"Spawning worker process: {executablePath} --worker");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            Arguments = "--worker",
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            // Pass through environment variables
+            Environment =
+            {
+                ["DOTNET_SOLUTION_PATH"] = "", // Don't auto-load in worker, we'll send load_solution
+                ["ROSLYN_LOG_LEVEL"] = Environment.GetEnvironmentVariable("ROSLYN_LOG_LEVEL") ?? "Information",
+                ["ROSLYN_TIMEOUT_SECONDS"] = Environment.GetEnvironmentVariable("ROSLYN_TIMEOUT_SECONDS") ?? "30",
+                ["ROSLYN_MAX_DIAGNOSTICS"] = Environment.GetEnvironmentVariable("ROSLYN_MAX_DIAGNOSTICS") ?? "100",
+                ["SHARPLENS_ABSOLUTE_PATHS"] = Environment.GetEnvironmentVariable("SHARPLENS_ABSOLUTE_PATHS") ?? "false"
+            }
+        };
+
+        var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+
+        process.Exited += OnWorkerExited;
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start worker process");
+        }
+
+        var proxy = new RoslynWorkerProxy(process);
+
+        // Start forwarding stderr (worker logs) with exception handling (fire-and-forget)
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await ForwardStderrAsync(process);
+            }
+            catch (Exception ex)
+            {
+                Log(LogLevel.Debug, $"Stderr forwarding ended: {ex.Message}");
+            }
+        });
+
+        lock (_lock)
+        {
+            _workerProcess = process;
+            _proxy = proxy;
+            WorkerStartTime = DateTime.UtcNow;
+        }
+
+        Log(LogLevel.Information, $"Worker process started (PID: {process.Id})");
+
+        // Verify worker is responsive
+        var pingOk = await proxy.PingAsync(5000);
+        if (!pingOk)
+        {
+            Log(LogLevel.Warning, "Worker did not respond to initial ping");
+        }
+
+        return proxy;
+    }
+
+    /// <summary>
+    /// Gracefully shuts down the worker, releasing file locks.
+    /// </summary>
+    public async Task<bool> ShutdownWorkerAsync(bool force = true, int gracefulTimeoutMs = 5000)
+    {
+        Process? process;
+        RoslynWorkerProxy? proxy;
+
+        lock (_lock)
+        {
+            process = _workerProcess;
+            proxy = _proxy;
+
+            if (process == null || process.HasExited)
+            {
+                CleanupWorker();
+                return true;
+            }
+        }
+
+        Log(LogLevel.Information, "Shutting down worker process...");
+
+        // Try graceful shutdown first
+        if (proxy != null)
+        {
+            var graceful = await proxy.ShutdownAsync(gracefulTimeoutMs);
+            if (graceful)
+            {
+                Log(LogLevel.Information, "Worker shut down gracefully");
+                CleanupWorker();
+                return true;
+            }
+        }
+
+        // Graceful failed, force kill if requested
+        if (force)
+        {
+            Log(LogLevel.Warning, "Graceful shutdown failed, force killing worker");
+            try
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(new CancellationTokenSource(2000).Token);
+            }
+            catch (Exception ex)
+            {
+                Log(LogLevel.Error, $"Error killing worker: {ex.Message}");
+            }
+        }
+
+        CleanupWorker();
+        return true;
+    }
+
+    private void OnWorkerExited(object? sender, EventArgs e)
+    {
+        lock (_lock)
+        {
+            var exitCode = _workerProcess?.ExitCode ?? -1;
+            Log(LogLevel.Warning, $"Worker process exited (exit code: {exitCode})");
+        }
+    }
+
+    private static async Task ForwardStderrAsync(Process process)
+    {
+        try
+        {
+            var reader = process.StandardError;
+            while (!process.HasExited)
+            {
+                var line = await reader.ReadLineAsync();
+                if (line == null) break;
+
+                // Forward worker logs to MCP stderr
+                Console.Error.WriteLine(line);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log(LogLevel.Debug, $"Stderr forwarding ended: {ex.Message}");
+        }
+    }
+
+    private void CleanupWorker()
+    {
+        lock (_lock)
+        {
+            _proxy?.Dispose();
+            _proxy = null;
+
+            if (_workerProcess != null)
+            {
+                _workerProcess.Exited -= OnWorkerExited;
+                try
+                {
+                    if (!_workerProcess.HasExited)
+                    {
+                        _workerProcess.Kill(entireProcessTree: true);
+                    }
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+                _workerProcess.Dispose();
+                _workerProcess = null;
+            }
+
+            WorkerStartTime = null;
+        }
+    }
+
+    private static void Log(LogLevel level, string message) => Logger.Log("ProcessManager", level, message);
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        CleanupWorker();
+        _spawnLock.Dispose();
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,9 +1,23 @@
 using Microsoft.Build.Locator;
 using SharpLensMcp;
 
-// Register MSBuild before any Roslyn code runs
-MSBuildLocator.RegisterDefaults();
+// Check for worker mode flag
+if (args.Contains("--worker"))
+{
+    // Worker mode: handles Roslyn analysis in a separate process
+    // Register MSBuild before any Roslyn code runs
+    MSBuildLocator.RegisterDefaults();
 
-// Create and run the MCP server
-var server = new McpServer();
-await server.RunAsync();
+    // Create and run the worker host (stdin/stdout JSON-RPC)
+    var roslynService = new RoslynService();
+    var workerHost = new WorkerHost(roslynService);
+    await workerHost.RunAsync();
+}
+else
+{
+    // MCP server mode: spawns worker process, proxies tool calls
+    // Note: MSBuildLocator not registered here - worker handles that
+    using var processManager = new ProcessManager();
+    var server = new McpServer(processManager);
+    await server.RunAsync();
+}

--- a/src/RoslynService.cs
+++ b/src/RoslynService.cs
@@ -309,10 +309,10 @@ public class RoslynService
         _documentCache.Clear();
 
         _workspace = MSBuildWorkspace.Create();
-        _workspace.WorkspaceFailed += (sender, args) =>
+        _workspace.RegisterWorkspaceFailedHandler(args =>
         {
-            Console.Error.WriteLine($"[Warning] Workspace: {args.Diagnostic.Message}");
-        };
+            Logger.Log("Workspace", LogLevel.Warning, args.Diagnostic.Message);
+        });
 
         _solution = await _workspace.OpenSolutionAsync(solutionPath);
         _solutionLoadedAt = DateTime.UtcNow;
@@ -1670,7 +1670,7 @@ public class RoslynService
 
         // Collect all changed documents
         var changedDocuments = new List<object>();
-        var solutionChanges = changedSolution.GetChanges(_solution!);
+        var solutionChanges = changedSolution!.GetChanges(_solution!);
 
         foreach (var projectChanges in solutionChanges.GetProjectChanges())
         {
@@ -2087,7 +2087,7 @@ public class RoslynService
                 referenceCount,
                 references = includeReferences ? (referenceCount > 100 ? references!.Concat(new[] { $"... and {referenceCount - 100} more" }).ToList() : references) : null,
                 projectReferences,
-                documents = includeDocuments ? (documentCount > 500 ? documents!.Concat(new[] { new { name = $"... and {documentCount - 500} more documents", filePath = (string?)null, folders = new List<string>() } }).ToList() : documents) : null
+                documents = includeDocuments ? (documentCount > 500 ? documents!.Concat(new[] { new { name = $"... and {documentCount - 500} more documents", filePath = "", folders = new List<string>() } }).ToList() : documents) : null               
             });
         }
 
@@ -7260,7 +7260,7 @@ public class ValidationClass {{
 
         // Collect all changed documents (reuse pattern from ApplyCodeFixAsync)
         var changedDocuments = new List<object>();
-        var solutionChanges = changedSolution.GetChanges(_solution!);
+        var solutionChanges = changedSolution!.GetChanges(_solution!);
 
         foreach (var projectChanges in solutionChanges.GetProjectChanges())
         {

--- a/src/RoslynWorkerProxy.cs
+++ b/src/RoslynWorkerProxy.cs
@@ -1,0 +1,230 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace SharpLensMcp;
+
+/// <summary>
+/// Proxies tool calls to the worker process via stdin/stdout JSON-RPC.
+/// Runs in the main process and communicates with WorkerHost in the worker process.
+/// Requests are processed sequentially (one at a time).
+/// </summary>
+public class RoslynWorkerProxy : IDisposable
+{
+    private readonly Process _workerProcess;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly CancellationTokenSource _shutdownCts = new();
+    private readonly Task _readerTask;
+    private readonly SemaphoreSlim _requestLock = new(1, 1);
+    private TaskCompletionSource<JsonObject>? _pendingResponse;
+    private bool _disposed;
+
+    public RoslynWorkerProxy(Process workerProcess)
+    {
+        _workerProcess = workerProcess ?? throw new ArgumentNullException(nameof(workerProcess));
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+
+        // Start reading responses from worker stdout
+        _readerTask = Task.Run(ReadResponsesAsync);
+    }
+
+    /// <summary>
+    /// Gets whether the worker process is still running.
+    /// </summary>
+    public bool IsWorkerAlive => !_workerProcess.HasExited;
+
+    /// <summary>
+    /// Gets the worker process ID.
+    /// </summary>
+    public int WorkerProcessId => _workerProcess.Id;
+
+    /// <summary>
+    /// Invokes a tool on the worker and returns the result.
+    /// </summary>
+    public async Task<object> InvokeToolAsync(string toolName, Dictionary<string, object?>? arguments, int timeoutMs = 30000)
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(RoslynWorkerProxy));
+
+        if (!IsWorkerAlive)
+            throw new InvalidOperationException("Worker process has exited");
+
+        var request = new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "invoke_tool",
+            @params = new
+            {
+                tool = toolName,
+                arguments = arguments ?? new Dictionary<string, object?>()
+            }
+        };
+
+        var response = await SendRequestAsync(request, timeoutMs);
+
+        // Check for JSON-RPC error
+        if (response.TryGetPropertyValue("error", out var errorNode) && errorNode != null)
+        {
+            var errorCode = errorNode["code"]?.GetValue<int>() ?? -1;
+            var errorMessage = errorNode["message"]?.GetValue<string>() ?? "Unknown error";
+            throw new InvalidOperationException($"Worker error ({errorCode}): {errorMessage}");
+        }
+
+        // Return the result
+        if (response.TryGetPropertyValue("result", out var resultNode) && resultNode != null)
+        {
+            return JsonSerializer.Deserialize<object>(resultNode.ToJsonString(), _jsonOptions)
+                ?? new { success = true };
+        }
+
+        return new { success = true };
+    }
+
+    /// <summary>
+    /// Sends a ping to verify worker is responsive.
+    /// </summary>
+    public async Task<bool> PingAsync(int timeoutMs = 5000)
+    {
+        if (_disposed || !IsWorkerAlive)
+            return false;
+
+        try
+        {
+            var request = new { jsonrpc = "2.0", id = 1, method = "ping" };
+            await SendRequestAsync(request, timeoutMs);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Shuts down the worker by closing stdin (triggering EOF).
+    /// </summary>
+    public async Task<bool> ShutdownAsync(int timeoutMs = 5000)
+    {
+        if (_disposed || !IsWorkerAlive)
+            return true;
+
+        try
+        {
+            // Close stdin to signal EOF - worker will exit gracefully
+            _workerProcess.StandardInput.Close();
+
+            // Wait for process to exit
+            using var exitCts = new CancellationTokenSource(timeoutMs);
+            await _workerProcess.WaitForExitAsync(exitCts.Token);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task<JsonObject> SendRequestAsync(object request, int timeoutMs)
+    {
+        await _requestLock.WaitAsync(_shutdownCts.Token);
+        try
+        {
+            var tcs = new TaskCompletionSource<JsonObject>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _pendingResponse = tcs;
+
+            var requestJson = JsonSerializer.Serialize(request, _jsonOptions);
+            LogDebug($"Sending to worker: {requestJson}");
+
+            await _workerProcess.StandardInput.WriteLineAsync(requestJson);
+            await _workerProcess.StandardInput.FlushAsync();
+
+            return await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs), _shutdownCts.Token);
+        }
+        catch (TimeoutException)
+        {
+            throw new TimeoutException($"Request timed out after {timeoutMs}ms");
+        }
+        finally
+        {
+            _pendingResponse = null;
+            _requestLock.Release();
+        }
+    }
+
+    private async Task ReadResponsesAsync()
+    {
+        try
+        {
+            var reader = _workerProcess.StandardOutput;
+
+            while (!_shutdownCts.Token.IsCancellationRequested && !_workerProcess.HasExited)
+            {
+                var line = await reader.ReadLineAsync();
+                if (line == null)
+                {
+                    LogDebug("Worker stdout closed (EOF)");
+                    break;
+                }
+
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                LogDebug($"Received from worker: {line}");
+
+                try
+                {
+                    var response = JsonSerializer.Deserialize<JsonObject>(line);
+                    if (response == null)
+                        continue;
+
+                    _pendingResponse?.TrySetResult(response);
+                }
+                catch (JsonException ex)
+                {
+                    LogDebug($"Failed to parse worker response: {ex.Message}");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown
+        }
+        catch (Exception ex)
+        {
+            LogDebug($"Reader task error: {ex}");
+        }
+        finally
+        {
+            _pendingResponse?.TrySetException(new InvalidOperationException("Worker connection closed"));
+        }
+    }
+
+    private static void LogDebug(string message) => Logger.Log("Proxy", LogLevel.Debug, message);
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _shutdownCts.Cancel();
+        _pendingResponse?.TrySetCanceled();
+
+        try
+        {
+            _readerTask.Wait(1000);
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+
+        _requestLock.Dispose();
+        _shutdownCts.Dispose();
+    }
+}

--- a/src/WorkerHost.cs
+++ b/src/WorkerHost.cs
@@ -1,0 +1,511 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace SharpLensMcp;
+
+/// <summary>
+/// Handles stdin/stdout JSON-RPC communication in worker mode.
+/// Receives tool invocation requests from the main process and routes them to RoslynService.
+/// </summary>
+public class WorkerHost
+{
+    private readonly RoslynService _roslynService;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly CancellationTokenSource _shutdownCts = new();
+
+    public WorkerHost(RoslynService roslynService)
+    {
+        _roslynService = roslynService;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    public async Task RunAsync()
+    {
+        Log(LogLevel.Information, "Worker process starting...");
+
+        using var reader = Console.In;
+        using var writer = Console.Out;
+
+        while (!_shutdownCts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var line = await reader.ReadLineAsync(_shutdownCts.Token);
+                if (line == null)
+                {
+                    Log(LogLevel.Information, "Received EOF on stdin, worker shutting down");
+                    break;
+                }
+
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                Log(LogLevel.Debug, $"Worker received: {line}");
+
+                var response = await HandleRequestAsync(line);
+
+                var responseJson = JsonSerializer.Serialize(response, _jsonOptions);
+                await writer.WriteLineAsync(responseJson);
+                await writer.FlushAsync();
+
+                Log(LogLevel.Debug, $"Worker sent: {responseJson}");
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log(LogLevel.Error, $"Worker error: {ex}");
+            }
+        }
+
+        Log(LogLevel.Information, "Worker process exiting");
+    }
+
+    private async Task<object> HandleRequestAsync(string requestJson)
+    {
+        try
+        {
+            var request = JsonSerializer.Deserialize<JsonObject>(requestJson);
+            if (request == null)
+            {
+                return CreateErrorResponse(null, -32700, "Parse error");
+            }
+
+            var id = request["id"];
+            var method = request["method"]?.GetValue<string>();
+            var paramsNode = request["params"]?.AsObject();
+
+            if (string.IsNullOrEmpty(method))
+            {
+                return CreateErrorResponse(id, -32600, "Invalid Request: missing method");
+            }
+
+            return method switch
+            {
+                "invoke_tool" => await HandleInvokeToolAsync(id, paramsNode),
+                "shutdown" => HandleShutdown(id),
+                "ping" => CreateSuccessResponse(id, new { pong = true, timestamp = DateTime.UtcNow }),
+                _ => CreateErrorResponse(id, -32601, $"Method not found: {method}")
+            };
+        }
+        catch (Exception ex)
+        {
+            Log(LogLevel.Error, $"Error handling request: {ex}");
+            return CreateErrorResponse(null, -32603, $"Internal error: {ex.Message}");
+        }
+    }
+
+    private async Task<object> HandleInvokeToolAsync(JsonNode? id, JsonObject? parameters)
+    {
+        if (parameters == null)
+        {
+            return CreateErrorResponse(id, -32602, "Invalid params: missing parameters");
+        }
+
+        var toolName = parameters["tool"]?.GetValue<string>();
+        var arguments = parameters["arguments"]?.AsObject();
+
+        if (string.IsNullOrEmpty(toolName))
+        {
+            return CreateErrorResponse(id, -32602, "Invalid params: missing tool name");
+        }
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var result = await InvokeRoslynToolAsync(toolName, arguments);
+            sw.Stop();
+            Log(LogLevel.Debug, $"Tool '{toolName}' completed in {sw.ElapsedMilliseconds}ms");
+            return CreateSuccessResponse(id, result);
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            Log(LogLevel.Error, $"Tool '{toolName}' failed after {sw.ElapsedMilliseconds}ms: {ex}");
+            return CreateErrorResponse(id, -32603, $"Tool error: {ex.Message}");
+        }
+    }
+
+    private object HandleShutdown(JsonNode? id)
+    {
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(100); // Give time for response to be sent
+            _shutdownCts.Cancel();
+        });
+        return CreateSuccessResponse(id, new { message = "Shutting down" });
+    }
+
+    private async Task<object> InvokeRoslynToolAsync(string toolName, JsonObject? arguments)
+    {
+        // Route tool calls to RoslynService methods
+        // This mirrors the switch statement in McpServer.HandleToolCallAsync
+        return toolName switch
+        {
+            "health_check" => await _roslynService.GetHealthCheckAsync(),
+            "load_solution" => await _roslynService.LoadSolutionAsync(
+                arguments?["solutionPath"]?.GetValue<string>() ?? throw new ArgumentException("solutionPath required")),
+            "sync_documents" => await _roslynService.SyncDocumentsAsync(
+                ParseStringArray(arguments?["filePaths"])),
+            "get_symbol_info" => await _roslynService.GetSymbolInfoAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required")),
+            "go_to_definition" => await _roslynService.GoToDefinitionAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required")),
+            "find_references" => await _roslynService.FindReferencesAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["maxResults"]?.GetValue<int>() ?? 100),
+            "find_implementations" => await _roslynService.FindImplementationsAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["maxResults"]?.GetValue<int>() ?? 50),
+            "get_type_hierarchy" => await _roslynService.GetTypeHierarchyAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["maxDerivedTypes"]?.GetValue<int>() ?? 50),
+            "search_symbols" => await _roslynService.SearchSymbolsAsync(
+                arguments?["query"]?.GetValue<string>() ?? throw new ArgumentException("query required"),
+                arguments?["kind"]?.GetValue<string>(),
+                arguments?["maxResults"]?.GetValue<int>() ?? 50,
+                arguments?["namespaceFilter"]?.GetValue<string>(),
+                arguments?["offset"]?.GetValue<int>() ?? 0),
+            "semantic_query" => await _roslynService.SemanticQueryAsync(
+                ParseStringArray(arguments?["kinds"]),
+                arguments?["isAsync"]?.GetValue<bool>(),
+                arguments?["namespaceFilter"]?.GetValue<string>(),
+                arguments?["accessibility"]?.GetValue<string>(),
+                arguments?["isStatic"]?.GetValue<bool>(),
+                arguments?["type"]?.GetValue<string>(),
+                arguments?["returnType"]?.GetValue<string>(),
+                ParseStringArray(arguments?["attributes"]),
+                ParseStringArray(arguments?["parameterIncludes"]),
+                ParseStringArray(arguments?["parameterExcludes"]),
+                arguments?["maxResults"]?.GetValue<int>() ?? 100),
+            "get_diagnostics" => await _roslynService.GetDiagnosticsAsync(
+                arguments?["filePath"]?.GetValue<string>(),
+                arguments?["projectPath"]?.GetValue<string>(),
+                arguments?["severity"]?.GetValue<string>(),
+                arguments?["includeHidden"]?.GetValue<bool>() ?? false),
+            "get_code_fixes" => await _roslynService.GetCodeFixesAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["diagnosticId"]?.GetValue<string>() ?? throw new ArgumentException("diagnosticId required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required")),
+            "apply_code_fix" => await _roslynService.ApplyCodeFixAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["diagnosticId"]?.GetValue<string>() ?? throw new ArgumentException("diagnosticId required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["fixIndex"]?.GetValue<int>(),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "get_project_structure" => await _roslynService.GetProjectStructureAsync(
+                arguments?["includeReferences"]?.GetValue<bool>() ?? true,
+                arguments?["includeDocuments"]?.GetValue<bool>() ?? false,
+                arguments?["projectNamePattern"]?.GetValue<string>(),
+                arguments?["maxProjects"]?.GetValue<int>(),
+                arguments?["summaryOnly"]?.GetValue<bool>() ?? false),
+            "organize_usings" => await _roslynService.OrganizeUsingsAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required")),
+            "organize_usings_batch" => await _roslynService.OrganizeUsingsBatchAsync(
+                arguments?["projectName"]?.GetValue<string>(),
+                arguments?["filePattern"]?.GetValue<string>(),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "format_document_batch" => await _roslynService.FormatDocumentBatchAsync(
+                arguments?["projectName"]?.GetValue<string>(),
+                arguments?["includeTests"]?.GetValue<bool>() ?? true,
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "get_method_overloads" => await _roslynService.GetMethodOverloadsAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required")),
+            "get_containing_member" => await _roslynService.GetContainingMemberAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required")),
+            "find_callers" => await _roslynService.FindCallersAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["maxResults"]?.GetValue<int>() ?? 100),
+            "find_unused_code" => await _roslynService.FindUnusedCodeAsync(
+                arguments?["projectName"]?.GetValue<string>(),
+                arguments?["includePrivate"]?.GetValue<bool>() ?? true,
+                arguments?["includeInternal"]?.GetValue<bool>() ?? false,
+                arguments?["symbolKindFilter"]?.GetValue<string>(),
+                arguments?["maxResults"]?.GetValue<int>() ?? 50),
+            "rename_symbol" => await _roslynService.RenameSymbolAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["newName"]?.GetValue<string>() ?? throw new ArgumentException("newName required"),
+                arguments?["preview"]?.GetValue<bool>() ?? true,
+                arguments?["maxFiles"]?.GetValue<int>() ?? 20,
+                arguments?["verbosity"]?.GetValue<string>() ?? "summary"),
+            "extract_interface" => await _roslynService.ExtractInterfaceAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["interfaceName"]?.GetValue<string>() ?? throw new ArgumentException("interfaceName required"),
+                ParseStringArray(arguments?["includeMemberNames"])),
+            "dependency_graph" => await _roslynService.GetDependencyGraphAsync(
+                arguments?["format"]?.GetValue<string>() ?? "json"),
+            "get_type_members" => await _roslynService.GetTypeMembersAsync(
+                arguments?["typeName"]?.GetValue<string>() ?? throw new ArgumentException("typeName required"),
+                arguments?["includeInherited"]?.GetValue<bool>() ?? false,
+                arguments?["memberKind"]?.GetValue<string>(),
+                arguments?["verbosity"]?.GetValue<string>() ?? "compact",
+                arguments?["maxResults"]?.GetValue<int>() ?? 100),
+            "get_method_signature" => await _roslynService.GetMethodSignatureAsync(
+                arguments?["typeName"]?.GetValue<string>() ?? throw new ArgumentException("typeName required"),
+                arguments?["methodName"]?.GetValue<string>() ?? throw new ArgumentException("methodName required"),
+                arguments?["overloadIndex"]?.GetValue<int>() ?? 0),
+            "get_attributes" => await _roslynService.GetAttributesAsync(
+                arguments?["attributeName"]?.GetValue<string>() ?? throw new ArgumentException("attributeName required"),
+                arguments?["scope"]?.GetValue<string>() ?? "solution",
+                true, // parseGodotHints
+                arguments?["maxResults"]?.GetValue<int>() ?? 100),
+            "get_derived_types" => await _roslynService.GetDerivedTypesAsync(
+                arguments?["baseTypeName"]?.GetValue<string>() ?? throw new ArgumentException("baseTypeName required"),
+                arguments?["includeTransitive"]?.GetValue<bool>() ?? true,
+                arguments?["maxResults"]?.GetValue<int>() ?? 100),
+            "get_base_types" => await _roslynService.GetBaseTypesAsync(
+                arguments?["typeName"]?.GetValue<string>() ?? throw new ArgumentException("typeName required")),
+            "analyze_data_flow" => await _roslynService.AnalyzeDataFlowAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["startLine"]?.GetValue<int>() ?? throw new ArgumentException("startLine required"),
+                arguments?["endLine"]?.GetValue<int>() ?? throw new ArgumentException("endLine required")),
+            "analyze_control_flow" => await _roslynService.AnalyzeControlFlowAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["startLine"]?.GetValue<int>() ?? throw new ArgumentException("startLine required"),
+                arguments?["endLine"]?.GetValue<int>() ?? throw new ArgumentException("endLine required")),
+            "get_type_overview" => await _roslynService.GetTypeOverviewAsync(
+                arguments?["typeName"]?.GetValue<string>() ?? throw new ArgumentException("typeName required")),
+            "analyze_method" => await _roslynService.AnalyzeMethodAsync(
+                arguments?["typeName"]?.GetValue<string>() ?? throw new ArgumentException("typeName required"),
+                arguments?["methodName"]?.GetValue<string>() ?? throw new ArgumentException("methodName required"),
+                arguments?["includeCallers"]?.GetValue<bool>() ?? true,
+                arguments?["includeOutgoingCalls"]?.GetValue<bool>() ?? false,
+                arguments?["maxCallers"]?.GetValue<int>() ?? 20,
+                arguments?["maxOutgoingCalls"]?.GetValue<int>() ?? 50),
+            "get_file_overview" => await _roslynService.GetFileOverviewAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required")),
+            "get_missing_members" => await _roslynService.GetMissingMembersAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required")),
+            "get_outgoing_calls" => await _roslynService.GetOutgoingCallsAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["maxDepth"]?.GetValue<int>() ?? 1),
+            "validate_code" => await _roslynService.ValidateCodeAsync(
+                arguments?["code"]?.GetValue<string>() ?? throw new ArgumentException("code required"),
+                arguments?["contextFilePath"]?.GetValue<string>(),
+                arguments?["standalone"]?.GetValue<bool>() ?? false),
+            "check_type_compatibility" => await _roslynService.CheckTypeCompatibilityAsync(
+                arguments?["sourceType"]?.GetValue<string>() ?? throw new ArgumentException("sourceType required"),
+                arguments?["targetType"]?.GetValue<string>() ?? throw new ArgumentException("targetType required")),
+            "get_instantiation_options" => await _roslynService.GetInstantiationOptionsAsync(
+                arguments?["typeName"]?.GetValue<string>() ?? throw new ArgumentException("typeName required")),
+            "analyze_change_impact" => await _roslynService.AnalyzeChangeImpactAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["changeType"]?.GetValue<string>() ?? throw new ArgumentException("changeType required"),
+                arguments?["newValue"]?.GetValue<string>()),
+            "get_method_source" => await _roslynService.GetMethodSourceAsync(
+                arguments?["typeName"]?.GetValue<string>() ?? throw new ArgumentException("typeName required"),
+                arguments?["methodName"]?.GetValue<string>() ?? throw new ArgumentException("methodName required"),
+                arguments?["overloadIndex"]?.GetValue<int>() ?? 0),
+            "get_method_source_batch" => await _roslynService.GetMethodSourceBatchAsync(
+                ParseMethodBatchRequestsAsDictList(arguments?["methods"]),
+                arguments?["maxMethods"]?.GetValue<int>() ?? 20),
+            "generate_constructor" => await _roslynService.GenerateConstructorAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["includeProperties"]?.GetValue<bool>() ?? false,
+                arguments?["initializeToDefault"]?.GetValue<bool>() ?? false),
+            "change_signature" => await _roslynService.ChangeSignatureAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                ParseSignatureChanges(arguments?["changes"]),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "extract_method" => await _roslynService.ExtractMethodAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["startLine"]?.GetValue<int>() ?? throw new ArgumentException("startLine required"),
+                arguments?["endLine"]?.GetValue<int>() ?? throw new ArgumentException("endLine required"),
+                arguments?["methodName"]?.GetValue<string>() ?? throw new ArgumentException("methodName required"),
+                arguments?["accessibility"]?.GetValue<string>() ?? "private",
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "get_code_actions_at_position" => await _roslynService.GetCodeActionsAtPositionAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["endLine"]?.GetValue<int>(),
+                arguments?["endColumn"]?.GetValue<int>(),
+                arguments?["includeRefactorings"]?.GetValue<bool>() ?? true,
+                arguments?["includeCodeFixes"]?.GetValue<bool>() ?? true),
+            "apply_code_action_by_title" => await _roslynService.ApplyCodeActionByTitleAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["title"]?.GetValue<string>() ?? throw new ArgumentException("title required"),
+                arguments?["endLine"]?.GetValue<int>(),
+                arguments?["endColumn"]?.GetValue<int>(),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "implement_missing_members" => await _roslynService.ImplementMissingMembersAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "encapsulate_field" => await _roslynService.EncapsulateFieldAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "inline_variable" => await _roslynService.InlineVariableAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "extract_variable" => await _roslynService.ExtractVariableAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["endLine"]?.GetValue<int>(),
+                arguments?["endColumn"]?.GetValue<int>(),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "get_complexity_metrics" => await _roslynService.GetComplexityMetricsAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>(),
+                arguments?["column"]?.GetValue<int>(),
+                ParseStringArray(arguments?["metrics"])),
+            "add_null_checks" => await _roslynService.AddNullChecksAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "generate_equality_members" => await _roslynService.GenerateEqualityMembersAsync(
+                arguments?["filePath"]?.GetValue<string>() ?? throw new ArgumentException("filePath required"),
+                arguments?["line"]?.GetValue<int>() ?? throw new ArgumentException("line required"),
+                arguments?["column"]?.GetValue<int>() ?? throw new ArgumentException("column required"),
+                arguments?["includeOperators"]?.GetValue<bool>() ?? true,
+                arguments?["preview"]?.GetValue<bool>() ?? true),
+            "get_type_members_batch" => await _roslynService.GetTypeMembersBatchAsync(
+                ParseStringArray(arguments?["typeNames"]) ?? throw new ArgumentException("typeNames required"),
+                arguments?["includeInherited"]?.GetValue<bool>() ?? false,
+                arguments?["memberKind"]?.GetValue<string>(),
+                arguments?["verbosity"]?.GetValue<string>() ?? "compact",
+                arguments?["maxResultsPerType"]?.GetValue<int>() ?? 50),
+            _ => throw new ArgumentException($"Unknown tool: {toolName}")
+        };
+    }
+
+    #region Helper Methods
+
+    private static List<string>? ParseStringArray(JsonNode? node)
+    {
+        if (node == null) return null;
+        if (node is JsonArray arr)
+        {
+            return arr.Select(n => n?.GetValue<string>() ?? "").Where(s => !string.IsNullOrEmpty(s)).ToList();
+        }
+        return null;
+    }
+
+    private static List<Dictionary<string, object>> ParseMethodBatchRequestsAsDictList(JsonNode? node)
+    {
+        var result = new List<Dictionary<string, object>>();
+        if (node is JsonArray arr)
+        {
+            foreach (var item in arr)
+            {
+                if (item is JsonObject obj)
+                {
+                    var dict = new Dictionary<string, object>();
+                    var typeName = obj["typeName"]?.GetValue<string>();
+                    var methodName = obj["methodName"]?.GetValue<string>();
+                    if (!string.IsNullOrEmpty(typeName) && !string.IsNullOrEmpty(methodName))
+                    {
+                        dict["typeName"] = typeName;
+                        dict["methodName"] = methodName;
+                        if (obj["overloadIndex"] != null)
+                        {
+                            dict["overloadIndex"] = obj["overloadIndex"]!.GetValue<int>();
+                        }
+                        result.Add(dict);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private static List<SignatureChange> ParseSignatureChanges(JsonNode? node)
+    {
+        var result = new List<SignatureChange>();
+        if (node is JsonArray arr)
+        {
+            foreach (var item in arr)
+            {
+                if (item is JsonObject obj)
+                {
+                    var action = obj["action"]?.GetValue<string>() ?? "";
+                    result.Add(new SignatureChange
+                    {
+                        Action = action,
+                        Name = obj["name"]?.GetValue<string>(),
+                        Type = obj["type"]?.GetValue<string>(),
+                        DefaultValue = obj["defaultValue"]?.GetValue<string>(),
+                        Position = obj["position"]?.GetValue<int>(),
+                        NewName = obj["newName"]?.GetValue<string>(),
+                        Order = action == "reorder" && obj["order"] is JsonArray orderArr
+                            ? orderArr.Select(n => n?.GetValue<string>() ?? "").ToList()
+                            : null
+                    });
+                }
+            }
+        }
+        return result;
+    }
+
+    private static object CreateSuccessResponse(JsonNode? id, object result)
+    {
+        return new
+        {
+            jsonrpc = "2.0",
+            id = id,
+            result
+        };
+    }
+
+    private static object CreateErrorResponse(JsonNode? id, int code, string message)
+    {
+        return new
+        {
+            jsonrpc = "2.0",
+            id = id,
+            error = new { code, message }
+        };
+    }
+
+    private static void Log(LogLevel level, string message) => Logger.Log("Worker", level, message);
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

This PR adds support for `unload_solution` by implementing an out-of-process worker architecture. This allows the MCP server to release all file locks (including source generator DLLs) by terminating the worker process, enabling clean rebuilds without restarting the entire server.

## Motivation

Previously, once a solution was loaded, MSBuildWorkspace held file locks that prevented rebuilding projects - particularly problematic for source generators. Users had to restart the MCP server entirely to release these locks.

With this change, calling `unload_solution` terminates the worker process, releasing all file handles immediately. The worker automatically respawns on the next tool call.

## Architecture

```
┌─────────────────┐     stdin/stdout      ┌─────────────────┐
│   MCP Client    │◄─────────────────────►│    McpServer    │
└─────────────────┘      JSON-RPC         │   (main proc)   │
                                          └────────┬────────┘
                                                   │
                                          ┌────────▼─────────┐
                                          │ ProcessManager   │
                                          │ RoslynWorkerProxy│
                                          └────────┬─────────┘
                                                   │ stdin/stdout
                                          ┌────────▼────────┐
                                          │   WorkerHost    │
                                          │  RoslynService  │
                                          │ (worker proc)   │
                                          └─────────────────┘
```

The same executable runs in two modes:
- **Main process**: Handles MCP protocol, spawns/manages worker
- **Worker process** (`--worker` flag): Loads solutions, executes Roslyn operations

## New Files

### `ProcessManager.cs`
Manages worker process lifecycle:
- Spawns worker process with `--worker` flag
- Monitors worker health via ping
- Handles graceful and forced termination
- Auto-respawns worker on next tool call after unload
- Forwards worker stderr for logging

### `RoslynWorkerProxy.cs`
Proxies tool calls to worker via JSON-RPC over stdin/stdout:
- Serializes requests, deserializes responses
- Handles timeouts with configurable duration
- Sequential request processing

### `WorkerHost.cs`
Runs in worker process:
- Reads JSON-RPC requests from stdin
- Routes to appropriate `RoslynService` methods
- Writes responses to stdout
- Handles `ping` and `shutdown` control messages

### `Logger.cs`
Shared logging utility for consistent log output across all components.

## Modified Files

### `McpServer.cs`
- Tool execution delegated to worker via `ProcessManager`
- Retains MCP protocol handling and tool definitions
- Routes all Roslyn operations through proxy

### `Program.cs`
Added worker mode entry point:
- Detects `--worker` command line flag
- Starts `WorkerHost` instead of `McpServer` in worker mode

### `RoslynService.cs`
- Updated to use `RegisterWorkspaceFailedHandler` (replaces deprecated API)

## Workflow

**Normal operation:**
1. MCP client sends tool request
2. `McpServer` forwards to `ProcessManager.EnsureWorkerAsync()`
3. Worker spawned if not running
4. Request proxied to worker via `RoslynWorkerProxy`
5. `WorkerHost` executes via `RoslynService`
6. Response returned through chain

**Unloading solution:**
1. Client calls `unload_solution`
2. `ProcessManager` sends shutdown signal to worker
3. Worker process terminates (releases all file locks)
4. Next tool call automatically spawns fresh worker

## Breaking Changes

None. All existing tools work identically. The `unload_solution` tool now actually releases file locks.

Disclaimer: Claude Code was used to generate much of this PR, using sharplens along the way. :)
